### PR TITLE
Add convar to disable control based checks

### DIFF
--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CitizenFX.Core;
@@ -21,7 +21,10 @@ namespace Client
             RequestAnimSet();
             RegisterCommands();
 
-            Tick += HandleControls;
+            if ((GetConvar("toastys_crouching_disable_controls", "false") ?? "false").ToLower() == "false")
+            {
+                Tick += HandleControls;
+            }
         }
 
         private void ToggleCrouch()

--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -19,7 +19,11 @@ namespace Client
         public Main()
         {
             RequestAnimSet();
-            RegisterCommands();
+            
+            if ((GetConvar("toastys_crouching_disable_commands", "false") ?? "false").ToLower() == "false")
+            {
+                RegisterCommands();
+            }
 
             if ((GetConvar("toastys_crouching_disable_controls", "false") ?? "false").ToLower() == "false")
             {


### PR DESCRIPTION
add `setr toastys_crouching_disable_controls true` to the server.cfg (above `start toastyscroucing`) if you want to disable controls.